### PR TITLE
Add pulled key(s) to return array

### DIFF
--- a/src/class-wp-request.php
+++ b/src/class-wp-request.php
@@ -192,7 +192,7 @@ class WP_Request {
         {
         	if ( $this->has( $key, $type ) )
         	{
-        		$results[] = $this->get( $key, $type );
+        		$results[ $key ] = $this->get( $key, $type );
         	}
         }
 


### PR DESCRIPTION
When pulling multiple items from the request, I feel it's more useable if the return array is associative, so that one doesn't have to rely upon numeric index
